### PR TITLE
Add missing source field to CreateOpportunity DTO typings

### DIFF
--- a/lib/code/opportunities/models/opportunities.ts
+++ b/lib/code/opportunities/models/opportunities.ts
@@ -107,6 +107,7 @@ export interface CreateDto {
   contactId: string;
   monetaryValue?: number;
   assignedTo?: string;
+  source?: string;
   customFields?: any[];
 }
 


### PR DESCRIPTION
The HighLevel Opportunities API already supports a `source` field:

* `GET /opportunities/{id}` includes `source` in the response.
* `PATCH /opportunities/{id}` (`updateOpportunity`) accepts a `source` field.
* The backend accepts `source` during creation, but the SDK typings currently block it.

Right now, the TypeScript definition for `CreateDto` omits `source`, which leads to:

* TS compilation errors when sending `source` in the create payload.
* Workarounds that rely on `@ts-expect-error` or loose casting.

Adds the missing, optional property:

```ts
export interface CreateDto {
    pipelineId: string;
    locationId: string;
    name: string;
    pipelineStageId?: string;
    status: string;
    contactId: string;
    monetaryValue?: number;
    assignedTo?: string;
    source?: string; // added
    customFields?: any[];
}
```

This aligns the SDK typings with the API model and the update endpoint behavior. The change is fully backwards compatible.

Verified that:

* The API successfully accepts a `source` value on create.
* The returned opportunity includes `source` when set.
* No breaking changes to existing users of the SDK.