### PR TITLE
Restore the contacts bulk tags endpoint to the documented public API shape

### DIFF
--- a/lib/code/contacts/contacts.ts
+++ b/lib/code/contacts/contacts.ts
@@ -627,13 +627,35 @@ export class Contacts {
    * @deprecated Use updateContactsTags instead.
    */
   async createAssociation(
+    requestBody: Models.UpdateTagsDTO,
+    options?: AxiosRequestConfig
+  ): Promise<Models.UpdateTagsResponseDTO>;
+  /**
+   * @deprecated Use updateContactsTags instead.
+   */
+  async createAssociation(
     params: {
       type: string;
     },
     requestBody: Models.UpdateTagsDTO,
     options?: AxiosRequestConfig
+  ): Promise<Models.UpdateTagsResponseDTO>;
+  async createAssociation(
+    paramsOrBody: { type: string } | Models.UpdateTagsDTO,
+    requestBodyOrOptions?: Models.UpdateTagsDTO | AxiosRequestConfig,
+    options?: AxiosRequestConfig
   ): Promise<Models.UpdateTagsResponseDTO> {
-    return this.updateContactsTags(params, requestBody, options);
+    if (typeof (paramsOrBody as any)?.type === 'string') {
+      return this.updateContactsTags(
+        paramsOrBody as { type: string },
+        requestBodyOrOptions as Models.UpdateTagsDTO,
+        options
+      );
+    }
+
+    throw new Error(
+      'Contacts.createAssociation is deprecated and now requires a `type` path param. Use updateContactsTags({ type }, requestBody, options).'
+    );
   }
 
   /**

--- a/lib/code/contacts/contacts.ts
+++ b/lib/code/contacts/contacts.ts
@@ -591,13 +591,16 @@ export class Contacts {
    * Update Contacts Tags
    * Allows you to update tags to multiple contacts at once, you can add or remove tags from the contacts
    */
-  async createAssociation(
+  async updateContactsTags(
+    params: {
+      type: string;
+    },
     requestBody: Models.UpdateTagsDTO,
     options?: AxiosRequestConfig
   ): Promise<Models.UpdateTagsResponseDTO> {
-    const paramDefs: Array<{name: string, in: string}> = [];
-    const extracted = extractParams(null, paramDefs);
-    const requirements: string[] = [];
+    const paramDefs: Array<{name: string, in: string}> = [{name: 'type', in: 'path'}];
+    const extracted = extractParams(params, paramDefs);
+    const requirements: string[] = ["bearer"];
     
     const config: RequestConfig = {
       method: 'POST',
@@ -618,6 +621,19 @@ export class Contacts {
 
     const response: AxiosResponse<Models.UpdateTagsResponseDTO> = await this.client.request(config);
     return response.data;
+  }
+
+  /**
+   * @deprecated Use updateContactsTags instead.
+   */
+  async createAssociation(
+    params: {
+      type: string;
+    },
+    requestBody: Models.UpdateTagsDTO,
+    options?: AxiosRequestConfig
+  ): Promise<Models.UpdateTagsResponseDTO> {
+    return this.updateContactsTags(params, requestBody, options);
   }
 
   /**

--- a/lib/code/contacts/contacts.ts
+++ b/lib/code/contacts/contacts.ts
@@ -593,7 +593,7 @@ export class Contacts {
    */
   async updateContactsTags(
     params: {
-      type: string;
+      type: 'add' | 'remove';
     },
     requestBody: Models.UpdateTagsDTO,
     options?: AxiosRequestConfig
@@ -635,19 +635,19 @@ export class Contacts {
    */
   async createAssociation(
     params: {
-      type: string;
+      type: 'add' | 'remove';
     },
     requestBody: Models.UpdateTagsDTO,
     options?: AxiosRequestConfig
   ): Promise<Models.UpdateTagsResponseDTO>;
   async createAssociation(
-    paramsOrBody: { type: string } | Models.UpdateTagsDTO,
+    paramsOrBody: { type: 'add' | 'remove' } | Models.UpdateTagsDTO,
     requestBodyOrOptions?: Models.UpdateTagsDTO | AxiosRequestConfig,
     options?: AxiosRequestConfig
   ): Promise<Models.UpdateTagsResponseDTO> {
     if (typeof (paramsOrBody as any)?.type === 'string') {
       return this.updateContactsTags(
-        paramsOrBody as { type: string },
+        paramsOrBody as { type: 'add' | 'remove' },
         requestBodyOrOptions as Models.UpdateTagsDTO,
         options
       );


### PR DESCRIPTION
The API route does not work without the type param.

Also, I updated the name to match the function.

See accidental breaking change: https://github.com/GoHighLevel/highlevel-api-sdk/commit/9ac8a3eb8a22754ac3eb12120995e4a5a571223f#diff-fdfd761ee67440d3620ac9dc1141fc35bf8488d4062fe43655736190fafc3642L601